### PR TITLE
Add database and images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+instance/
+*.pyc
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pigeon Marketplace
 
-This is a simple Flask web app for buying and selling pigeons. Listings are stored in-memory, so data will reset each time the server restarts.
+This is a small Flask web app for buying and selling pigeons. Listings are stored in a local SQLite database with optional images. Data persists between restarts and you can edit or delete existing pigeons.
 
 ## Setup
 
@@ -13,5 +13,9 @@ This is a simple Flask web app for buying and selling pigeons. Listings are stor
    ```bash
    python app.py
    ```
+
+The app will create a `db.sqlite3` file in the project directory on first run. Images uploaded for listings are saved in `static/uploads`.
+
+For production, set the `SECRET_KEY` environment variable to a strong value before starting the server.
 
 Visit `http://localhost:5000` in your browser to see the marketplace.

--- a/app.py
+++ b/app.py
@@ -1,23 +1,82 @@
-from flask import Flask, render_template, request, redirect, url_for
+from flask import Flask, render_template, request, redirect, url_for, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import FlaskForm
+from wtforms import StringField, DecimalField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired, NumberRange
+from werkzeug.utils import secure_filename
+import os
 
 app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db.sqlite3'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change-me')
+app.config['UPLOAD_FOLDER'] = os.path.join('static', 'uploads')
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 
-# In-memory list to store pigeon listings
-pigeons = []
+db = SQLAlchemy(app)
+with app.app_context():
+    db.create_all()
+
+class Pigeon(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    price = db.Column(db.Numeric(10, 2), nullable=False)
+    image = db.Column(db.String(120))
+
+class PigeonForm(FlaskForm):
+    name = StringField('Name', validators=[DataRequired()])
+    description = TextAreaField('Description', validators=[DataRequired()])
+    price = DecimalField('Price', places=2, validators=[DataRequired(), NumberRange(min=0)])
+    submit = SubmitField('Save')
+
 
 @app.route('/')
 def index():
+    pigeons = Pigeon.query.all()
     return render_template('index.html', pigeons=pigeons)
 
 @app.route('/add', methods=['GET', 'POST'])
 def add_pigeon():
-    if request.method == 'POST':
-        name = request.form.get('name')
-        description = request.form.get('description')
-        price = request.form.get('price')
-        pigeons.append({'name': name, 'description': description, 'price': price})
+    form = PigeonForm()
+    if form.validate_on_submit():
+        filename = None
+        file = request.files.get('image')
+        if file and file.filename:
+            filename = secure_filename(file.filename)
+            file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+        pigeon = Pigeon(name=form.name.data, description=form.description.data,
+                        price=form.price.data, image=filename)
+        db.session.add(pigeon)
+        db.session.commit()
+        flash('Pigeon added!')
         return redirect(url_for('index'))
-    return render_template('add.html')
+    return render_template('add.html', form=form)
+
+@app.route('/edit/<int:pigeon_id>', methods=['GET', 'POST'])
+def edit_pigeon(pigeon_id):
+    pigeon = Pigeon.query.get_or_404(pigeon_id)
+    form = PigeonForm(obj=pigeon)
+    if form.validate_on_submit():
+        filename = pigeon.image
+        file = request.files.get('image')
+        if file and file.filename:
+            filename = secure_filename(file.filename)
+            file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+        form.populate_obj(pigeon)
+        pigeon.image = filename
+        db.session.commit()
+        flash('Pigeon updated!')
+        return redirect(url_for('index'))
+    return render_template('edit.html', form=form, pigeon=pigeon)
+
+@app.route('/delete/<int:pigeon_id>', methods=['POST'])
+def delete_pigeon(pigeon_id):
+    pigeon = Pigeon.query.get_or_404(pigeon_id)
+    db.session.delete(pigeon)
+    db.session.commit()
+    flash('Pigeon deleted!')
+    return redirect(url_for('index'))
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 flask==2.3.2
+flask_sqlalchemy==3.0.5
+flask_wtf==1.2.2
+wtforms==3.1.1

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,90 +1,14 @@
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
     background: #f0f4f8;
-    color: #333;
-}
-
-header {
-    background: linear-gradient(90deg, #4e54c8, #8f94fb);
-    color: #fff;
-    padding: 20px;
-    text-align: center;
-}
-header h1 {
-    margin: 0;
-    font-size: 2em;
-}
-header nav {
-    margin-top: 10px;
-}
-header nav a {
-    color: #fff;
-    margin: 0 10px;
-    text-decoration: none;
-    font-weight: bold;
-}
-header nav a:hover {
-    text-decoration: underline;
 }
 
 main {
-    max-width: 800px;
-    margin: 20px auto;
     background: #fff;
     padding: 20px;
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-ul.pigeons {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-.pigeon-card {
-    border-bottom: 1px solid #eee;
-    padding: 10px 0;
-}
-.pigeon-card:last-child {
-    border-bottom: none;
-}
-.pigeon-card strong {
-    font-size: 1.2em;
-}
-
-form label {
-    display: block;
-    margin-top: 10px;
-}
-form input,
-form textarea {
-    width: 100%;
-    padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-sizing: border-box;
-}
-form textarea {
-    resize: vertical;
-    height: 80px;
-}
-button {
-    background: #4e54c8;
-    color: #fff;
-    border: none;
-    padding: 10px 20px;
-    border-radius: 4px;
-    cursor: pointer;
-    margin-top: 10px;
-}
-button:hover {
-    background: #3639a1;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 footer {
-    text-align: center;
-    padding: 20px;
     color: #777;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,21 +1,40 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Pigeon Marketplace{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-  <header>
-    <h1><a href="{{ url_for('index') }}" style="color:inherit; text-decoration:none;">Pigeon Marketplace</a></h1>
-    <nav>
-      <a href="{{ url_for('index') }}">Home</a>
-      <a href="{{ url_for('add_pigeon') }}">Add a Pigeon</a>
-    </nav>
-  </header>
-  <main>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container">
+      <a class="navbar-brand" href="{{ url_for('index') }}">Pigeon Marketplace</a>
+      <div class="collapse navbar-collapse">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('add_pigeon') }}">Add a Pigeon</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="alert alert-info">
+          {% for message in messages %}
+            {{ message }}<br>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
     {% block content %}{% endblock %}
   </main>
-  <footer>&copy; 2024 Pigeon Marketplace</footer>
+
+  <footer class="text-center py-4 text-muted">&copy; 2024 Pigeon Marketplace</footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 
-{% block title %}Add Pigeon{% endblock %}
+{% block title %}Edit Pigeon{% endblock %}
 
 {% block content %}
-  <h2 class="mb-4">Add a New Pigeon</h2>
+  <h2 class="mb-4">Edit {{ pigeon.name }}</h2>
   <form method="post" enctype="multipart/form-data">
     {{ form.hidden_tag() }}
     <div class="mb-3">
@@ -24,6 +24,9 @@
     <div class="mb-3">
       <label class="form-label" for="image">Image</label>
       <input class="form-control" type="file" name="image" id="image">
+      {% if pigeon.image %}
+        <img src="{{ url_for('static', filename='uploads/' ~ pigeon.image) }}" alt="{{ pigeon.name }}" class="img-thumbnail mt-2" style="max-height: 150px;">
+      {% endif %}
     </div>
     {{ form.submit(class="btn btn-primary") }}
   </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,13 +4,30 @@
 
 {% block content %}
   {% if pigeons %}
-    <ul class="pigeons">
+    <div class="row g-4">
       {% for pigeon in pigeons %}
-        <li class="pigeon-card">
-          <strong>{{ pigeon.name }}</strong> - {{ pigeon.description }} - ${{ pigeon.price }}
-        </li>
+        <div class="col-md-4">
+          <div class="card h-100">
+            {% if pigeon.image %}
+              <img src="{{ url_for('static', filename='uploads/' ~ pigeon.image) }}" class="card-img-top" alt="{{ pigeon.name }}">
+            {% endif %}
+            <div class="card-body">
+              <h5 class="card-title">{{ pigeon.name }}</h5>
+              <p class="card-text">{{ pigeon.description }}</p>
+            </div>
+            <div class="card-footer d-flex justify-content-between align-items-center">
+              <span class="fw-bold">${{ '%.2f'|format(pigeon.price) }}</span>
+              <span>
+                <a href="{{ url_for('edit_pigeon', pigeon_id=pigeon.id) }}" class="btn btn-sm btn-primary">Edit</a>
+                <form action="{{ url_for('delete_pigeon', pigeon_id=pigeon.id) }}" method="post" class="d-inline">
+                  <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this pigeon?');">Delete</button>
+                </form>
+              </span>
+            </div>
+          </div>
+        </div>
       {% endfor %}
-    </ul>
+    </div>
   {% else %}
     <p>No pigeons listed yet.</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- hook up SQLAlchemy with SQLite
- support adding pigeon images, editing & deleting pigeons
- add Bootstrap styling and flash messages
- update README instructions
- ignore instance and cache files

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py` *(runs server)*

------
https://chatgpt.com/codex/tasks/task_e_685a1238caec832daf844b254ba4a141